### PR TITLE
[rna] add package publishing support

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id("com.facebook.react.codegen")
     id("maven-publish")
     id("de.undercouch.download")
+    id("com.google.cloud.artifactregistry.gradle-plugin") version "2.1.1"
 }
 
 import java.nio.file.Paths
@@ -597,8 +598,8 @@ afterEvaluate {
 
         repositories {
             maven {
-                name = "npm"
-                url = AAR_OUTPUT_URL
+                name = "discord"
+                url = uri("gcs://discord-maven")
             }
         }
     }

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.66.4
+VERSION_NAME=0.66.4-discord-1
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/discord/bump_version.py
+++ b/discord/bump_version.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import re
+import subprocess
+
+VERSION_MATCHER = re.compile(r'^(.*)-discord-(\d*)$')
+
+status_bytes = subprocess.check_output(['git', 'status', '--porcelain'])
+status = status_bytes.decode('utf-8').strip()
+assert status == '', f'Detected changed files, please remove or commit.\n\n{status}'
+
+root_bytes = subprocess.check_output(['git', 'rev-parse', '--show-toplevel'])
+root = root_bytes.decode('utf-8').strip()
+android_path = Path(root) / "ReactAndroid"
+props_path = android_path / "gradle.properties"
+
+version = None
+property_lines = [line.strip() for line in props_path.read_text().splitlines()]
+for line in property_lines:
+    if line.startswith("VERSION_NAME="):
+        version = line.split('=')[1]
+
+assert version, "unable to find current version"
+
+matches = VERSION_MATCHER.match(version)
+assert matches, f'{version} did not match expected format, X.Y.Z-discord-N'
+
+upstream = matches[1]
+local = int(matches[2])
+
+new_version = f'{upstream}-discord-{local + 1}'
+
+with open(props_path, 'w') as f:
+    for line in property_lines:
+        if line.startswith("VERSION_NAME="):
+            f.write(f'VERSION_NAME={new_version}\n')
+        else:
+            f.write(f'{line}\n')
+
+
+branch_name_bytes = subprocess.check_output(['git', 'symbolic-ref', '--short', 'HEAD'])
+branch_name = branch_name_bytes.decode('utf-8').strip()
+
+subprocess.check_call(['../gradlew', 'publishReleasePublicationToDiscordRepository'], cwd=android_path.absolute())
+
+subprocess.check_call(['git', 'add', props_path.absolute()])
+subprocess.check_call(['git', 'commit', '-m', f'Bumping to version {new_version}'])
+subprocess.check_call(['git', 'push', 'origin', branch_name])
+
+print(f'NEW TAGGED VERSION: {new_version}')


### PR DESCRIPTION
a few changes to enable publishing to our internal repository.

run `discord/bump_version.py`, it'll ensure the repo is clean, update the version as expected and publish the artifact.