### PR TITLE
animate switch on value change

### DIFF
--- a/React/Views/RCTSwitchManager.m
+++ b/React/Views/RCTSwitchManager.m
@@ -49,7 +49,17 @@ RCT_EXPORT_METHOD(setValue : (nonnull NSNumber *)viewTag toValue : (BOOL)value)
 RCT_EXPORT_VIEW_PROPERTY(onTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(thumbTintColor, UIColor);
-RCT_REMAP_VIEW_PROPERTY(value, on, BOOL);
+//RCT_REMAP_VIEW_PROPERTY(value, on, BOOL);
+RCT_CUSTOM_VIEW_PROPERTY(value, BOOL, RCTSwitch)
+{
+    if (json) {
+        BOOL on = [RCTConvert BOOL:json];
+        if (view.wasOn != on) {
+            [(UISwitch *)view setOn:on animated:YES];
+            view.wasOn = on;
+        }
+    }
+}
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock);
 RCT_CUSTOM_VIEW_PROPERTY(disabled, BOOL, RCTSwitch)
 {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently, the switch does not animate when its value changes. This makes it jank when we try to programmatically toggle it by changing its value. For example, I want to allow toggling the switch by pressing it's label (https://github.com/discord/discord/pull/67835) but since the switch doesn't animate when the value changes, the interaction looks horrible. 

This PR makes it so that the switch animates when its value changes. The current switch code maps the `on` value of the switch to the value passed in from JS. However, setting the `on` value this way does not animate.
```
RCT_REMAP_VIEW_PROPERTY(value, on, BOOL);
```
To fix that, I replaced it with
```
RCT_CUSTOM_VIEW_PROPERTY(value, BOOL, RCTSwitch)
{
    if (json) {
        BOOL on = [RCTConvert BOOL:json];
        if (view.wasOn != on) {
            [(UISwitch *)view setOn:on animated:YES];
            view.wasOn = on;
        }
    }
}
```


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Changed] - Animate switch on value change

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Add js code that toggles the switch value. See that it is now animated. Here's a video of a before (on the left) and after (on the right):


https://user-images.githubusercontent.com/7124039/162099494-083097bc-671a-44e3-89c0-75e2df10bdfb.mp4


