### PR TITLE
Android 7/8/9: force keyboard to show when ReactEditText is clicked

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -212,15 +212,7 @@ public class ReactEditText extends AppCompatEditText
         clickDetector.handleDown(ev);
         break;
       case MotionEvent.ACTION_UP:
-        final boolean wasClick = clickDetector.handleUp(ev);
-        if (wasClick && forceShowKeyboardOnClicks() && isEnabled()) {
-          /*
-           It is intentional that we do not return true here.
-           We want to force the keyboard to show, but we still want to allow the user
-           to interact with the view in other ways (like changing the selection).
-          */
-          showSoftKeyboard();
-        }
+        handleTouchUp();
         break;
       case MotionEvent.ACTION_CANCEL:
         clickDetector.cancelPress();
@@ -1088,6 +1080,18 @@ public class ReactEditText extends AppCompatEditText
    */
   private boolean forceShowKeyboardOnClicks() {
     return Build.VERSION.SDK_INT <= Build.VERSION_CODES.P;
+  }
+
+  private void handleTouchUp() {
+    final boolean wasClick = clickDetector.handleUp(ev);
+    if (wasClick && forceShowKeyboardOnClicks() && isEnabled()) {
+      /*
+      It is intentional that we do not return true here from onTouchEvent.
+      We want to force the keyboard to show, but we still want to allow the user
+      to interact with the view in other ways (like changing the selection).
+      */
+      showSoftKeyboard();
+    }
   }
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -212,7 +212,7 @@ public class ReactEditText extends AppCompatEditText
         clickDetector.handleDown(ev);
         break;
       case MotionEvent.ACTION_UP:
-        handleTouchUp();
+        clickDetector.handleUp(ev);
         break;
       case MotionEvent.ACTION_CANCEL:
         clickDetector.cancelPress();
@@ -1071,27 +1071,6 @@ public class ReactEditText extends AppCompatEditText
 
   void setEventDispatcher(@Nullable EventDispatcher eventDispatcher) {
     mEventDispatcher = eventDispatcher;
-  }
-
-  /**
-   * There is a bug on Android 7/8/9 where clicking the view while it is already
-   * focused does not show the keyboard. On those API levels, we force showing
-   * the keyboard when we detect a click.
-   */
-  private boolean forceShowKeyboardOnClicks() {
-    return Build.VERSION.SDK_INT <= Build.VERSION_CODES.P;
-  }
-
-  private void handleTouchUp() {
-    final boolean wasClick = clickDetector.handleUp(ev);
-    if (wasClick && forceShowKeyboardOnClicks() && isEnabled()) {
-      /*
-      It is intentional that we do not return true here from onTouchEvent.
-      We want to force the keyboard to show, but we still want to allow the user
-      to interact with the view in other ways (like changing the selection).
-      */
-      showSoftKeyboard();
-    }
   }
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextClickDetector.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextClickDetector.java
@@ -1,0 +1,77 @@
+package com.facebook.react.views.textinput;
+
+import android.view.MotionEvent;
+import android.view.View;
+
+import androidx.annotation.Nullable;
+
+class ReactEditTextClickDetector {
+
+  private static final long MAX_CLICK_DURATION_MS = 250L;
+  private static final int MAX_CLICK_DISTANCE_DP = 12;
+
+  private final float screenDensity;
+
+  @Nullable
+  private TimestampedMotionEvent currentDownEvent;
+
+  public ReactEditTextClickDetector(final View view) {
+    screenDensity = view.getResources().getDisplayMetrics().density;
+  }
+
+  void handleDown(final MotionEvent downEvent) {
+    currentDownEvent = new TimestampedMotionEvent(downEvent);
+  }
+
+  void cancelPress() {
+    currentDownEvent = null;
+  }
+
+  /**
+   * @return true if the event was a click.
+   */
+  boolean handleUp(final MotionEvent upEvent) {
+    if (currentDownEvent == null) {
+      return false;
+    }
+
+    final TimestampedMotionEvent downEvent = currentDownEvent;
+    currentDownEvent = null;
+
+    // make sure the press event was close enough in time
+    final long now = System.currentTimeMillis();
+    final long timeDelta = now - downEvent.timestamp;
+    if (timeDelta > MAX_CLICK_DURATION_MS) {
+      return false;
+    }
+
+    // make sure the press event was close enough in distance
+    final float oldX = downEvent.motionEvent.getRawX();
+    final float oldY = downEvent.motionEvent.getRawY();
+    final float newX = upEvent.getRawX();
+    final float newY = upEvent.getRawY();
+
+    // distance = sqrt((x2 − x1)^2 + (y2 − y1)^2)
+    final double distancePx = Math.sqrt(
+      Math.pow((newX - oldX), 2) + Math.pow((newY - oldY), 2)
+    );
+
+    double distanceDp = distancePx / screenDensity;
+    return distanceDp <= MAX_CLICK_DISTANCE_DP;
+  }
+
+  private static class TimestampedMotionEvent {
+
+    final long timestamp;
+    final MotionEvent motionEvent;
+
+    public TimestampedMotionEvent(final long timestamp, final MotionEvent motionEvent) {
+      this.timestamp = timestamp;
+      this.motionEvent = motionEvent;
+    }
+
+    public TimestampedMotionEvent(final MotionEvent motionEvent) {
+      this(System.currentTimeMillis(), motionEvent);
+    }
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextClickDetector.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextClickDetector.java
@@ -20,7 +20,7 @@ class ReactEditTextClickDetector {
   }
 
   void handleDown(final MotionEvent downEvent) {
-    currentDownEvent = new TimestampedMotionEvent(downEvent);
+    currentDownEvent = new TimestampedMotionEvent(System.currentTimeMillis(), downEvent);
   }
 
   void cancelPress() {
@@ -65,13 +65,9 @@ class ReactEditTextClickDetector {
     final long timestamp;
     final MotionEvent motionEvent;
 
-    public TimestampedMotionEvent(final long timestamp, final MotionEvent motionEvent) {
+    TimestampedMotionEvent(final long timestamp, final MotionEvent motionEvent) {
       this.timestamp = timestamp;
       this.motionEvent = motionEvent;
-    }
-
-    public TimestampedMotionEvent(final MotionEvent motionEvent) {
-      this(System.currentTimeMillis(), motionEvent);
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextClickDetector.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextClickDetector.java
@@ -1,5 +1,6 @@
 package com.facebook.react.views.textinput;
 
+import android.os.Build;
 import android.view.MotionEvent;
 import android.view.View;
 
@@ -10,39 +11,44 @@ class ReactEditTextClickDetector {
   private static final long MAX_CLICK_DURATION_MS = 250L;
   private static final int MAX_CLICK_DISTANCE_DP = 12;
 
+  private final ReactEditText reactEditText;
   private final float screenDensity;
 
   @Nullable
   private TimestampedMotionEvent currentDownEvent;
 
-  public ReactEditTextClickDetector(final View view) {
-    screenDensity = view.getResources().getDisplayMetrics().density;
+  public ReactEditTextClickDetector(final ReactEditText reactEditText) {
+    this.reactEditText = reactEditText;
+    screenDensity = reactEditText.getResources().getDisplayMetrics().density;
   }
 
   void handleDown(final MotionEvent downEvent) {
-    currentDownEvent = new TimestampedMotionEvent(System.currentTimeMillis(), downEvent);
+    currentDownEvent = new TimestampedMotionEvent(downEvent);
   }
 
   void cancelPress() {
     currentDownEvent = null;
   }
 
-  /**
-   * @return true if the event was a click.
-   */
-  boolean handleUp(final MotionEvent upEvent) {
+  void handleUp(final MotionEvent upEvent) {
     if (currentDownEvent == null) {
-      return false;
+      return;
     }
 
     final TimestampedMotionEvent downEvent = currentDownEvent;
     currentDownEvent = null;
 
+    // for now, if we're not forcing showing the keyboard on clicks, we don't care if it was a
+    // click. we also early return if the view is not enabled.
+    if (!(forceShowKeyboardOnClicks() && reactEditText.isEnabled())) {
+      return;
+    }
+
     // make sure the press event was close enough in time
     final long now = System.currentTimeMillis();
     final long timeDelta = now - downEvent.timestamp;
     if (timeDelta > MAX_CLICK_DURATION_MS) {
-      return false;
+      return;
     }
 
     // make sure the press event was close enough in distance
@@ -57,7 +63,20 @@ class ReactEditTextClickDetector {
     );
 
     double distanceDp = distancePx / screenDensity;
-    return distanceDp <= MAX_CLICK_DISTANCE_DP;
+    if (distanceDp > MAX_CLICK_DISTANCE_DP) {
+      return;
+    }
+
+    reactEditText.showSoftKeyboard();
+  }
+
+  /**
+   * There is a bug on Android 7/8/9 where clicking the view while it is already
+   * focused does not show the keyboard. On those API levels, we force showing
+   * the keyboard when we detect a click.
+   */
+  private static boolean forceShowKeyboardOnClicks() {
+    return Build.VERSION.SDK_INT <= Build.VERSION_CODES.P;
   }
 
   private static class TimestampedMotionEvent {


### PR DESCRIPTION
There is a tracked issue in react native where on Android 7/8/9 (and maybe lower), the keyboard will not show up if an already-focused ReactEditText is clicked: https://github.com/facebook/react-native/issues/31374

this is easy to repro by dismissing the keyboard using the system back button, then trying to click the edittext.

this PR fixes that by detecting clicks on the view and forcing the keyboard to show if on android 9 or lower.

i'm sure there will be downsides to this approach but i think it gets us out the door for rna.