### PR TITLE
expose `flush` on RCTWebSocketModule to close all open websockets synchronously

### DIFF
--- a/Libraries/WebSocket/RCTSRWebSocket.h
+++ b/Libraries/WebSocket/RCTSRWebSocket.h
@@ -80,6 +80,8 @@ extern NSString *const RCTSRHTTPResponseErrorKey;
 - (void)open;
 
 - (void)close;
+- (void)closeSync;
+
 - (void)closeWithCode:(NSInteger)code reason:(NSString *)reason;
 
 // Send a UTF8 String or Data.

--- a/Libraries/WebSocket/RCTSRWebSocket.h
+++ b/Libraries/WebSocket/RCTSRWebSocket.h
@@ -80,7 +80,7 @@ extern NSString *const RCTSRHTTPResponseErrorKey;
 - (void)open;
 
 - (void)close;
-- (void)closeSync;
+- (void)flush;
 
 - (void)closeWithCode:(NSInteger)code reason:(NSString *)reason;
 

--- a/React/CoreModules/RCTWebSocketModule.h
+++ b/React/CoreModules/RCTWebSocketModule.h
@@ -24,6 +24,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sendData:(NSData *)data forSocketID:(nonnull NSNumber *)socketID;
 
+// Closes all open websockets on the main thread
+- (void)flush;
+
 @end
 
 @interface RCTBridge (RCTWebSocketModule)

--- a/React/CoreModules/RCTWebSocketModule.h
+++ b/React/CoreModules/RCTWebSocketModule.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sendData:(NSData *)data forSocketID:(nonnull NSNumber *)socketID;
 
-// Closes all open websockets on the main thread
+// Blocking call that waits until there are no more remaining actions on the queue
 - (void)flush;
 
 @end

--- a/React/CoreModules/RCTWebSocketModule.mm
+++ b/React/CoreModules/RCTWebSocketModule.mm
@@ -51,6 +51,16 @@ RCT_EXPORT_MODULE()
   return @[ @"websocketMessage", @"websocketOpen", @"websocketFailed", @"websocketClosed" ];
 }
 
+
+- (void)flush
+{
+  _contentHandlers = nil;
+  for (RCTSRWebSocket *socket in _sockets.allValues) {
+    socket.delegate = nil;
+    [socket closeSync];
+  }
+}
+
 - (void)invalidate
 {
   [super invalidate];

--- a/React/CoreModules/RCTWebSocketModule.mm
+++ b/React/CoreModules/RCTWebSocketModule.mm
@@ -54,10 +54,8 @@ RCT_EXPORT_MODULE()
 
 - (void)flush
 {
-  _contentHandlers = nil;
   for (RCTSRWebSocket *socket in _sockets.allValues) {
-    socket.delegate = nil;
-    [socket closeSync];
+    [socket flush];
   }
 }
 


### PR DESCRIPTION
There was a bit of plumbing to do as there were multiple assertions done along the way to ensure this work is done on the workQueue thread.

I tested this out by adding a sleep of 2 seconds inside closeWithCode block. Seems to work fine.

See:  https://www.notion.so/discordapp/RFC-Mobile-Gracefully-closing-the-Gateway-Socket-on-App-Termination-69b44fb46f4e4fedbbca7102e9e2ac29 for more info
