### PR TITLE
Add preventClipping prop

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -123,6 +123,8 @@ public class ReactEditText extends AppCompatEditText
   private static final KeyListener sKeyListener = QwertyKeyListener.getInstanceForFullKeyboard();
   private @Nullable EventDispatcher mEventDispatcher;
 
+  private final ReactEditTextClickDetector clickDetector = new ReactEditTextClickDetector(this);
+
   public ReactEditText(Context context) {
     super(context);
     setFocusableInTouchMode(false);
@@ -207,6 +209,13 @@ public class ReactEditText extends AppCompatEditText
         // Disallow parent views to intercept touch events, until we can detect if we should be
         // capturing these touches or not.
         this.getParent().requestDisallowInterceptTouchEvent(true);
+        clickDetector.handleDown(ev);
+        break;
+      case MotionEvent.ACTION_UP:
+        clickDetector.handleUp(ev);
+        break;
+      case MotionEvent.ACTION_CANCEL:
+        clickDetector.cancelPress();
         break;
       case MotionEvent.ACTION_MOVE:
         if (mDetectScrollMovement) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextClickDetector.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextClickDetector.java
@@ -1,0 +1,92 @@
+package com.facebook.react.views.textinput;
+
+import android.os.Build;
+import android.view.MotionEvent;
+import android.view.View;
+
+import androidx.annotation.Nullable;
+
+class ReactEditTextClickDetector {
+
+  private static final long MAX_CLICK_DURATION_MS = 250L;
+  private static final int MAX_CLICK_DISTANCE_DP = 12;
+
+  private final ReactEditText reactEditText;
+  private final float screenDensity;
+
+  @Nullable
+  private TimestampedMotionEvent currentDownEvent;
+
+  public ReactEditTextClickDetector(final ReactEditText reactEditText) {
+    this.reactEditText = reactEditText;
+    screenDensity = reactEditText.getResources().getDisplayMetrics().density;
+  }
+
+  void handleDown(final MotionEvent downEvent) {
+    currentDownEvent = new TimestampedMotionEvent(downEvent);
+  }
+
+  void cancelPress() {
+    currentDownEvent = null;
+  }
+
+  void handleUp(final MotionEvent upEvent) {
+    if (currentDownEvent == null) {
+      return;
+    }
+
+    final TimestampedMotionEvent downEvent = currentDownEvent;
+    currentDownEvent = null;
+
+    // for now, if we're not forcing showing the keyboard on clicks, we don't care if it was a
+    // click. we also early return if the view is not enabled.
+    if (!(forceShowKeyboardOnClicks() && reactEditText.isEnabled())) {
+      return;
+    }
+
+    // make sure the press event was close enough in time
+    final long now = System.currentTimeMillis();
+    final long timeDelta = now - downEvent.timestamp;
+    if (timeDelta > MAX_CLICK_DURATION_MS) {
+      return;
+    }
+
+    // make sure the press event was close enough in distance
+    final float oldX = downEvent.motionEvent.getRawX();
+    final float oldY = downEvent.motionEvent.getRawY();
+    final float newX = upEvent.getRawX();
+    final float newY = upEvent.getRawY();
+
+    // distance = sqrt((x2 − x1)^2 + (y2 − y1)^2)
+    final double distancePx = Math.sqrt(
+      Math.pow((newX - oldX), 2) + Math.pow((newY - oldY), 2)
+    );
+
+    double distanceDp = distancePx / screenDensity;
+    if (distanceDp > MAX_CLICK_DISTANCE_DP) {
+      return;
+    }
+
+    reactEditText.showSoftKeyboard();
+  }
+
+  /**
+   * There is a bug on Android 7/8/9 where clicking the view while it is already
+   * focused does not show the keyboard. On those API levels, we force showing
+   * the keyboard when we detect a click.
+   */
+  private static boolean forceShowKeyboardOnClicks() {
+    return Build.VERSION.SDK_INT <= Build.VERSION_CODES.P;
+  }
+
+  private static class TimestampedMotionEvent {
+
+    final long timestamp;
+    final MotionEvent motionEvent;
+
+    TimestampedMotionEvent(final long timestamp, final MotionEvent motionEvent) {
+      this.timestamp = timestamp;
+      this.motionEvent = motionEvent;
+    }
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -131,6 +131,7 @@ public class ReactViewGroup extends ViewGroup
   private int mLayoutDirection;
   private float mBackfaceOpacity = 1.f;
   private String mBackfaceVisibility = "visible";
+  private boolean mPreventClipping = false;
 
   public ReactViewGroup(Context context) {
     super(context);
@@ -279,6 +280,19 @@ public class ReactViewGroup extends ViewGroup
     getOrCreateReactViewBackground().setBorderStyle(style);
   }
 
+  public void setPreventClipping(boolean preventClipping) {
+    mPreventClipping = preventClipping;
+
+    // TODO(apkumar)
+    //
+    // It would be nice to trigger the LayoutChangeListener at this point.
+  }
+
+  public boolean getPreventClipping() {
+    return mPreventClipping;
+  }
+
+
   @Override
   public void setRemoveClippedSubviews(boolean removeClippedSubviews) {
     if (removeClippedSubviews == mRemoveClippedSubviews) {
@@ -366,7 +380,13 @@ public class ReactViewGroup extends ViewGroup
     // it won't be size and located properly.
     Animation animation = child.getAnimation();
     boolean isAnimating = animation != null && !animation.hasEnded();
-    if (!intersects && child.getParent() != null && !isAnimating) {
+
+    boolean preventClipping = false;
+    if (child instanceof ReactViewGroup) {
+      preventClipping = ((ReactViewGroup)child).getPreventClipping();
+    }
+
+    if (!intersects && child.getParent() != null && !isAnimating && !preventClipping) {
       // We can try saving on invalidate call here as the view that we remove is out of visible area
       // therefore invalidation is not necessary.
       super.removeViewsInLayout(idx - clippedSoFar, 1);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -391,11 +391,11 @@ public class ReactViewGroup extends ViewGroup
       // therefore invalidation is not necessary.
       super.removeViewsInLayout(idx - clippedSoFar, 1);
       needUpdateClippingRecursive = true;
-    } else if (intersects && child.getParent() == null) {
+    } else if ((intersects || preventClipping) && child.getParent() == null) {
       super.addViewInLayout(child, idx - clippedSoFar, sDefaultLayoutParam, true);
       invalidate();
       needUpdateClippingRecursive = true;
-    } else if (intersects) {
+    } else if (intersects || preventClipping) {
       // If there is any intersection we need to inform the child to update its clipping rect
       needUpdateClippingRecursive = true;
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -63,9 +63,6 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
     view.setFocusable(accessible);
   }
 
-  @ReactProp(name = "preventClipping")
-  public void setPreventClipping(ReactViewGroup view, bool
-
   @ReactProp(name = "hasTVPreferredFocus")
   public void setTVPreferredFocus(ReactViewGroup view, boolean hasTVPreferredFocus) {
     if (hasTVPreferredFocus) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -53,10 +53,18 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
   private static final int CMD_SET_PRESSED = 2;
   private static final String HOTSPOT_UPDATE_KEY = "hotspotUpdate";
 
+  @ReactProp(name = "preventClipping")
+  public void setPreventClipping(ReactViewGroup view, boolean preventClipping) {
+    view.setPreventClipping(preventClipping);
+  }
+
   @ReactProp(name = "accessible")
   public void setAccessible(ReactViewGroup view, boolean accessible) {
     view.setFocusable(accessible);
   }
+
+  @ReactProp(name = "preventClipping")
+  public void setPreventClipping(ReactViewGroup view, bool
 
   @ReactProp(name = "hasTVPreferredFocus")
   public void setTVPreferredFocus(ReactViewGroup view, boolean hasTVPreferredFocus) {


### PR DESCRIPTION
Adds a `preventClipping` prop to Views that causes them to never be clipped when the parent has `removeClippedSubviews` turned on.