### PR TITLE
Adding cornerRadius to Pressable RippleConfig

### DIFF
--- a/Libraries/Components/Pressable/useAndroidRippleForView.js
+++ b/Libraries/Components/Pressable/useAndroidRippleForView.js
@@ -21,7 +21,7 @@ type NativeBackgroundProp = $ReadOnly<{|
   color: ?number,
   borderless: boolean,
   rippleRadius: ?number,
-  cornerRippleRadius: ?number,
+  rippleCornerRadius: ?number,
 |}>;
 
 export type RippleConfig = {|
@@ -47,7 +47,8 @@ export default function useAndroidRippleForView(
     | $ReadOnly<{|nativeBackgroundAndroid: NativeBackgroundProp|}>
     | $ReadOnly<{|nativeForegroundAndroid: NativeBackgroundProp|}>,
 |}> {
-  const {color, borderless, radius, cornerRadius, foreground} = rippleConfig ?? {};
+  const {color, borderless, radius, cornerRadius, foreground} =
+    rippleConfig ?? {};
 
   return useMemo(() => {
     if (
@@ -66,7 +67,7 @@ export default function useAndroidRippleForView(
         color: processedColor,
         borderless: borderless === true,
         rippleRadius: radius,
-        cornerRippleRadius: cornerRadius,
+        rippleCornerRadius: cornerRadius,
       };
 
       return {

--- a/Libraries/Components/Pressable/useAndroidRippleForView.js
+++ b/Libraries/Components/Pressable/useAndroidRippleForView.js
@@ -21,12 +21,14 @@ type NativeBackgroundProp = $ReadOnly<{|
   color: ?number,
   borderless: boolean,
   rippleRadius: ?number,
+  cornerRippleRadius: ?number,
 |}>;
 
 export type RippleConfig = {|
   color?: ColorValue,
   borderless?: boolean,
   radius?: number,
+  cornerRadius?: number,
   foreground?: boolean,
 |};
 
@@ -45,7 +47,7 @@ export default function useAndroidRippleForView(
     | $ReadOnly<{|nativeBackgroundAndroid: NativeBackgroundProp|}>
     | $ReadOnly<{|nativeForegroundAndroid: NativeBackgroundProp|}>,
 |}> {
-  const {color, borderless, radius, foreground} = rippleConfig ?? {};
+  const {color, borderless, radius, cornerRadius, foreground} = rippleConfig ?? {};
 
   return useMemo(() => {
     if (
@@ -64,6 +66,7 @@ export default function useAndroidRippleForView(
         color: processedColor,
         borderless: borderless === true,
         rippleRadius: radius,
+        cornerRippleRadius: cornerRadius,
       };
 
       return {

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -231,6 +231,7 @@ type AndroidDrawableRipple = $ReadOnly<{|
   color?: ?number,
   borderless?: ?boolean,
   rippleRadius?: ?number,
+  rippleCornerRadius?: ?number,
 |}>;
 
 type AndroidDrawable = AndroidDrawableThemeAttr | AndroidDrawableRipple;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -14,6 +14,8 @@ import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.RippleDrawable;
+import android.graphics.drawable.ShapeDrawable;
+import android.graphics.drawable.shapes.RoundRectShape;
 import android.os.Build;
 import android.util.TypedValue;
 import androidx.annotation.Nullable;
@@ -22,6 +24,8 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.SoftAssertions;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ViewProps;
+
+import java.util.Collections;
 
 /**
  * Utility class that helps with converting android drawable description used in JS to an actual
@@ -45,8 +49,7 @@ public class ReactDrawableHelper {
       Drawable drawable = getDefaultThemeDrawable(context);
       return setRadius(drawableDescriptionDict, drawable);
     } else if ("RippleAndroid".equals(type)) {
-      RippleDrawable rd = getRippleDrawable(context, drawableDescriptionDict);
-      return setRadius(drawableDescriptionDict, rd);
+      return getRippleDrawable(context, drawableDescriptionDict);
     } else {
       throw new JSApplicationIllegalArgumentException("Invalid type for android drawable: " + type);
     }
@@ -106,11 +109,16 @@ public class ReactDrawableHelper {
   }
 
   private static @Nullable Drawable getMask(ReadableMap drawableDescriptionDict) {
-    if (!drawableDescriptionDict.hasKey("borderless")
-        || drawableDescriptionDict.isNull("borderless")
-        || !drawableDescriptionDict.getBoolean("borderless")) {
-      return new ColorDrawable(Color.WHITE);
+    if (drawableDescriptionDict.hasKey("borderless") && drawableDescriptionDict.getBoolean("borderless")) {
+      // Borderless ripples don't have masks.
+      return null;
     }
-    return null;
+
+    if (drawableDescriptionDict.hasKey("rippleRadius")) {
+      float rippleRadius = PixelUtil.toPixelFromDIP(drawableDescriptionDict.getDouble("rippleRadius"));
+      return new ShapeDrawable(new RoundRectShape(new float[] {rippleRadius, rippleRadius, rippleRadius, rippleRadius, rippleRadius, rippleRadius, rippleRadius, rippleRadius}, null, null));
+    }
+
+    return new ColorDrawable(Color.WHITE);
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -49,7 +49,8 @@ public class ReactDrawableHelper {
       Drawable drawable = getDefaultThemeDrawable(context);
       return setRadius(drawableDescriptionDict, drawable);
     } else if ("RippleAndroid".equals(type)) {
-      return getRippleDrawable(context, drawableDescriptionDict);
+      RippleDrawable rd = getRippleDrawable(context, drawableDescriptionDict);
+      return setRadius(drawableDescriptionDict, rd);
     } else {
       throw new JSApplicationIllegalArgumentException("Invalid type for android drawable: " + type);
     }
@@ -114,8 +115,8 @@ public class ReactDrawableHelper {
       return null;
     }
 
-    if (drawableDescriptionDict.hasKey("rippleRadius")) {
-      float rippleRadius = PixelUtil.toPixelFromDIP(drawableDescriptionDict.getDouble("rippleRadius"));
+    if (drawableDescriptionDict.hasKey("cornerRippleRadius")) {
+      float rippleRadius = PixelUtil.toPixelFromDIP(drawableDescriptionDict.getDouble("cornerRippleRadius"));
       return new ShapeDrawable(new RoundRectShape(new float[] {rippleRadius, rippleRadius, rippleRadius, rippleRadius, rippleRadius, rippleRadius, rippleRadius, rippleRadius}, null, null));
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -113,8 +113,8 @@ public class ReactDrawableHelper {
       return null;
     }
 
-    if (drawableDescriptionDict.hasKey("cornerRippleRadius")) {
-      float rippleRadius = PixelUtil.toPixelFromDIP(drawableDescriptionDict.getDouble("cornerRippleRadius"));
+    if (drawableDescriptionDict.hasKey("rippleCornerRadius")) {
+      float rippleRadius = PixelUtil.toPixelFromDIP(drawableDescriptionDict.getDouble("rippleCornerRadius"));
       return new ShapeDrawable(new RoundRectShape(new float[] {rippleRadius, rippleRadius, rippleRadius, rippleRadius, rippleRadius, rippleRadius, rippleRadius, rippleRadius}, null, null));
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -25,8 +25,6 @@ import com.facebook.react.bridge.SoftAssertions;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ViewProps;
 
-import java.util.Collections;
-
 /**
  * Utility class that helps with converting android drawable description used in JS to an actual
  * instance of {@link Drawable}.


### PR DESCRIPTION
**In This PR..**

Adding `cornerRadius` to `Pressable` `RippleConfig`

This is part of the `Pressable` refactor saga, which began here:
https://github.com/discord/discord/pull/73789

The above PR made it so we masked the `Pressable` at the Javascript level; nesting the `Pressable` in a `View` with `overflow: hidden` and its corner radii defined, and having the `children` be sibling to the `Pressable` instead of actually as `children`. This unfortunately broke screen readers, so the sibling part of the PR has since been reverted here: https://github.com/discord/discord/pull/76318

Now, instead of masking at the Javascript level, we're masking at the Java level. **This PR does not change the look of any ripples in the app.** Though I have tested that setting `cornerRadius` does correctly set the corner radii of the ripple.
