### PR TITLE
Fix ScrollView component occasionally producing strange flings

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -20,6 +20,7 @@ import android.graphics.Color;
 import android.graphics.Rect;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -439,18 +439,7 @@ public class ReactScrollView extends ScrollView
 
   @Override
   public void fling(int velocityY) {
-    // Workaround.
-    // On Android P if a ScrollView is inverted, we will get a wrong sign for
-    // velocityY (see https://issuetracker.google.com/issues/112385925).
-    // At the same time, mOnScrollDispatchHelper tracks the correct velocity direction.
-    //
-    // Hence, we can use the absolute value from whatever the OS gives
-    // us and use the sign of what mOnScrollDispatchHelper has tracked.
-    float signum = Math.signum(mOnScrollDispatchHelper.getYFlingVelocity());
-    if (signum == 0) {
-      signum = Math.signum(velocityY);
-    }
-    final int correctedVelocityYOld = (int) (Math.abs(velocityY) * signum);
+    final int correctedVelocityYOld = adjustFlingVelocitySign(velocityY);
     final int correctedVelocityY;
     if (MAX_FLING_VELOCITY != null) {
       correctedVelocityY = (int) ((Math.min(Math.abs(correctedVelocityYOld), MAX_FLING_VELOCITY)) *
@@ -494,6 +483,25 @@ public class ReactScrollView extends ScrollView
       super.fling(correctedVelocityY);
     }
     handlePostTouchScrolling(0, correctedVelocityY);
+  }
+
+  private int adjustFlingVelocitySign(int velocityY) {
+    if (Build.VERSION.SDK_INT != Build.VERSION_CODES.P) {
+      return velocityY;
+    }
+
+    // Workaround.
+    // On Android P if a ScrollView is inverted, we will get a wrong sign for
+    // velocityY (see https://issuetracker.google.com/issues/112385925).
+    // At the same time, mOnScrollDispatchHelper tracks the correct velocity direction.
+    //
+    // Hence, we can use the absolute value from whatever the OS gives
+    // us and use the sign of what mOnScrollDispatchHelper has tracked.
+    float signum = Math.signum(mOnScrollDispatchHelper.getYFlingVelocity());
+    if (signum == 0) {
+      signum = Math.signum(velocityY);
+    }
+    return (int) (Math.abs(velocityY) * signum);
   }
 
   private void enableFpsListener() {


### PR DESCRIPTION
See https://app.asana.com/0/1200546912788443/1202237077179474/f and, specifically, the bug reported filed [here](https://github.com/facebook/react-native/issues/34226).

Long story short, the workaround Facebook introduced for a platform bug occasionally results in flings that do not reflect the expected fling direction. My experimental fix here is to *only* apply this fix on platform versions affected by the bug (IE: `P`). We could be a bit more conservative and also apply the workaround on `Q`/10 and I'd still be happy (my phone's running 12) but I'm not sure that we need to. [The bug](https://issuetracker.google.com/issues/112385925) was marked fixed in March 2019, and `Q` was released that September, so it *should* be fine.
