### PR TITLE
Fix android reduced motion accessibility setting

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
@@ -108,10 +108,10 @@ public class AccessibilityInfoModule extends NativeAccessibilityInfoSpec
 
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private boolean getIsReduceMotionEnabledValue() {
-    String value =
+    String rawValue =
         Settings.Global.getString(mContentResolver, Settings.Global.TRANSITION_ANIMATION_SCALE);
-
-    return value != null && value.equals("0.0");
+    float floatValue = Float.parseFloat(rawValue);
+    return value != null && value == 0f;
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
@@ -108,9 +108,9 @@ public class AccessibilityInfoModule extends NativeAccessibilityInfoSpec
 
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private boolean getIsReduceMotionEnabledValue() {
-    String rawValue =
-        Settings.Global.getString(mContentResolver, Settings.Global.TRANSITION_ANIMATION_SCALE);
-    return rawValue != null && Float.parseFloat(rawValue) == 0f;
+    float defaultAnimationScale = Float.parseFloat(Settings.Global.TRANSITION_ANIMATION_SCALE);
+    float animationScale = Settings.Global.getFloat(mContentResolver, defaultAnimationScale);
+    return animationScale == 0f;
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
@@ -110,8 +110,7 @@ public class AccessibilityInfoModule extends NativeAccessibilityInfoSpec
   private boolean getIsReduceMotionEnabledValue() {
     String rawValue =
         Settings.Global.getString(mContentResolver, Settings.Global.TRANSITION_ANIMATION_SCALE);
-    float floatValue = Float.parseFloat(rawValue);
-    return value != null && value == 0f;
+    return rawValue != null && Float.parseFloat(rawValue) == 0f;
   }
 
   @Override


### PR DESCRIPTION
this is an attempt to fix this issue on our fork: https://github.com/facebook/react-native/issues/31221

homie in [this comment](https://github.com/facebook/react-native/issues/31221#issuecomment-1114365526) has identified a fix. the tl;dr is that the react native code was checking to see if the value (as a string) was "`0.0`", but it's more appropriate to check against the float value (because it is possible that the string was set to something else, like just `"0"`.

i have confirmed that this fixes the root-cause bug of RN not reading this setting properly.