### PR TITLE
[RNA] Align text

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
@@ -23,7 +23,7 @@ public class CustomLineHeightSpan implements LineHeightSpan, ReactSpan {
 
   @Override
   public void chooseHeight(
-    CharSequence text, int start, int end, int spanstartv, int v, Paint.FontMetricsInt fm) {
+      CharSequence text, int start, int end, int spanstartv, int v, Paint.FontMetricsInt fm) {
 
     if (OVERRIDE_LINE_HEIGHT) {
       overrideLineHeight(fm);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
@@ -23,7 +23,13 @@ public class CustomLineHeightSpan implements LineHeightSpan, ReactSpan {
 
   @Override
   public void chooseHeight(
-      CharSequence text, int start, int end, int spanstartv, int v, Paint.FontMetricsInt fm) {
+    CharSequence text, int start, int end, int spanstartv, int v, Paint.FontMetricsInt fm) {
+
+    if (OVERRIDE_LINE_HEIGHT) {
+      overrideLineHeight(fm);
+      return;
+    }
+
     // This is more complicated that I wanted it to be. You can find a good explanation of what the
     // FontMetrics mean here: http://stackoverflow.com/questions/27631736.
     // The general solution is that if there's not enough height to show the full line height, we
@@ -45,6 +51,43 @@ public class CustomLineHeightSpan implements LineHeightSpan, ReactSpan {
       // Show all ascent, descent, bottom, as much top as possible
       fm.top = fm.bottom - mHeight;
     } else {
+      // Show proportionally additional ascent / top & descent / bottom
+      final int additional = mHeight - (-fm.top + fm.bottom);
+
+      // Round up for the negative values and down for the positive values  (arbitrary choice)
+      // So that bottom - top equals additional even if it's an odd number.
+      fm.top -= Math.ceil(additional / 2.0f);
+      fm.bottom += Math.floor(additional / 2.0f);
+      fm.ascent = fm.top;
+      fm.descent = fm.bottom;
+    }
+  }
+
+  private final static boolean OVERRIDE_LINE_HEIGHT = true;
+
+  /**
+   * Discord Story time!
+   *
+   * So since we decided to be _very_ flexible with channel names, users have decided that they were gonna name their channels
+   * shit like ‧͙⁺˚･༓☾text☽༓･˚⁺‧͙ | l̶̟̦͚͎̦͑̎m̵̮̥̫͕͚̜̱̫̺̪͍̯̉̂̔͌́̚̕a̶͖̫͍͇̯̯̭͎͋̅́̿́̕͘͘͝͝ò̶̧̢͎̃̋͆̉͠ | and other fun non-standard channel names.
+   *
+   * This caused issues with line heights, because the RN implementation decided that it would try as best as possible to
+   * fit the text within the lineHeight that was given to it by the react component, causing text to be shifted upward
+   * and look terrible (see: https://canary.discord.com/channels/281683040739262465/912423796915462154/101286117376867126
+   * for an example).
+   *
+   * We (Jerry + Charles) decided that to fix this issue, we would instead ignore lineHeights _only_ if the text
+   * height was larger than the lineHeight provided to it.
+   *
+   * This is a much simpler implementation that what was previously here.
+   *
+   * _IF_ the lineHeight is larger than the text height, we default to centering the text as much as possible within
+   * that line height.
+   */
+  private void overrideLineHeight(Paint.FontMetricsInt fm) {
+    int realTextHeight = fm.bottom - fm.top;
+
+    if (mHeight >= realTextHeight) {
       // Show proportionally additional ascent / top & descent / bottom
       final int additional = mHeight - (-fm.top + fm.bottom);
 


### PR DESCRIPTION
Fixing an issue where RNA would purposely shift text to respect lineHeights. See comments in code for more explanation.

See https://www.notion.so/discordapp/Line-Break-Before-After-aa67103b451f48d09267c2ab19e0b53d for comparison of before/afters