### PR TITLE
websocket: include reception timestamp in all events.

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -239,7 +239,7 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
             data = BlobManager.createFromOptions(ev.data);
             break;
         }
-        this.dispatchEvent(new WebSocketEvent('message', {data}));
+        this.dispatchEvent(new WebSocketEvent('message', {data, timestamp: ev.timestamp}));
       }),
       this._eventEmitter.addListener('websocketOpen', ev => {
         if (ev.id !== this._socketId) {
@@ -247,7 +247,7 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
         }
         this.readyState = this.OPEN;
         this.protocol = ev.protocol;
-        this.dispatchEvent(new WebSocketEvent('open'));
+        this.dispatchEvent(new WebSocketEvent('open', {timestamp: ev.timestamp}));
       }),
       this._eventEmitter.addListener('websocketClosed', ev => {
         if (ev.id !== this._socketId) {
@@ -258,6 +258,7 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
           new WebSocketEvent('close', {
             code: ev.code,
             reason: ev.reason,
+            timestamp: ev.timestamp,
           }),
         );
         this._unregisterEvents();
@@ -271,11 +272,13 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
         this.dispatchEvent(
           new WebSocketEvent('error', {
             message: ev.message,
+            timestamp: ev.timestamp,
           }),
         );
         this.dispatchEvent(
           new WebSocketEvent('close', {
             message: ev.message,
+            timestamp: ev.timestamp,
           }),
         );
         this._unregisterEvents();

--- a/React/CoreModules/RCTWebSocketModule.h
+++ b/React/CoreModules/RCTWebSocketModule.h
@@ -24,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sendData:(NSData *)data forSocketID:(nonnull NSNumber *)socketID;
 
+- (void)sendEventWithName:(NSString *)name body:(NSDictionary *)body;
+
 // Blocking call that waits until there are no more remaining actions on the queue
 - (void)flush;
 

--- a/React/CoreModules/RCTWebSocketModule.mm
+++ b/React/CoreModules/RCTWebSocketModule.mm
@@ -16,6 +16,13 @@
 
 #import "CoreModulesPlugins.h"
 
+(NSNumber)currentJsDate
+{
+  double seconds = [NSDate timeIntervalSinceReferenceDate] + NSTimeIntervalSince1970;
+
+  return [NSNumber numberWithLong: seconds * 1000];
+}
+
 @implementation RCTSRWebSocket (React)
 
 - (NSNumber *)reactTag
@@ -200,6 +207,15 @@ RCT_EXPORT_METHOD(close : (double)code reason : (NSString *)reason socketID : (d
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {
   return std::make_shared<facebook::react::NativeWebSocketModuleSpecJSI>(params);
+}
+
+- (void)sendEventWithName:(NSString *)name
+                     body:(NSDictionary *)body
+{
+  NSMutableDictionary *mutableBody = [body mutableCopy];
+  mutableBody["timestamp"] = currentJsDate();
+
+  [super sendEventWithName:name body:mutableBody]
 }
 
 @end

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -69,6 +69,8 @@ public final class WebSocketModule extends NativeWebSocketModuleSpec {
     ReactApplicationContext reactApplicationContext = getReactApplicationContextIfActiveOrWarn();
 
     if (reactApplicationContext != null) {
+      params.putDouble("timestamp", System.currentTimeMillis());
+
       reactApplicationContext
           .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
           .emit(eventName, params);


### PR DESCRIPTION
adds a reception timestamp to all websocket events emitted by react-native. allows us to measure the delay between receiving the message and our js thread becoming free and able to process it.