### PR TITLE
Remove RN Android's bizarre font weight extension pattern

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
@@ -189,13 +189,11 @@ public class ReactFontManager {
     // Iterate over the list of fontFamilyNames, constructing new FontFamily objects
     // for use in the CustomFallbackBuilder below.
     for (String fontFamilyName : fontFamilyNames) {
-      String extension = EXTENSIONS[style];
       for (String fileExtension : FILE_EXTENSIONS) {
         String fileName =
           new StringBuilder()
             .append(FONTS_ASSET_PATH)
             .append(fontFamilyName)
-            .append(extension)
             .append(fileExtension)
             .toString();
         try {
@@ -210,6 +208,11 @@ public class ReactFontManager {
           continue;
         }
       }
+    }
+
+    // If there's some problem constructing fonts, fall back to the default behavior.
+    if (fontFamilies.size() == 0) {
+      return createAssetTypeface(fontFamilyNames[0], style, assetManager);
     }
 
     Typeface.CustomFallbackBuilder fallbackBuilder = new Typeface.CustomFallbackBuilder(fontFamilies.get(0));


### PR DESCRIPTION
This is a simple change to ignore the way that RN's Android code searches for fonts with a `_bold`, `_italic`, or `_bold_italic` suffix in their filename. In Discord's codebase we just declare the font family, but some of our libraries don't just do that.

We'll need to revert this change once we rework how we do fonts on RN (since currently we're a bit off-book).