### PR TITLE
Adding Discord-only TurboModule support

### DIFF
--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniH.js
@@ -125,7 +125,15 @@ add_library(
   \${react_codegen_SRCS}
 )
 
-target_include_directories(react_codegen_${libraryName} PUBLIC . react/renderer/components/${libraryName})
+# ADDED STUFF FOR DISCORD THINGS (See GenerateModuleJniH.js in the react-native repo)
+
+if(DEFINED PREBUILT_CMAKE)
+    include(\${PREBUILT_CMAKE})
+endif()
+
+target_include_directories(react_codegen_RTNTurboModuleTest PUBLIC . react/renderer/components/${libraryName} \${EXTRA_INCLUDE_DIRECTORIES})
+
+# END ADDED STUFF FOR DISCORD THINGS
 
 target_link_libraries(
   react_codegen_${libraryName}

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -11,6 +11,7 @@ import com.android.build.gradle.AppExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.internal.tasks.factory.dependsOn
+import com.facebook.react.model.ModelPackageJson
 import com.facebook.react.tasks.BuildCodegenCLITask
 import com.facebook.react.tasks.GenerateCodegenArtifactsTask
 import com.facebook.react.tasks.GenerateCodegenSchemaTask
@@ -103,6 +104,8 @@ class ReactPlugin : Plugin<Project> {
           } else {
             it.jsRootDir.set(extension.jsRootDir)
           }
+
+          it.onlyIf { project.needsCodegenFromPackageJson(parsedPackageJson) }
         }
 
     // We create the task to generate Java code from schema.
@@ -118,6 +121,14 @@ class ReactPlugin : Plugin<Project> {
           it.packageJsonFile.set(findPackageJsonFile(project, extension))
           it.codegenJavaPackageName.set(extension.codegenJavaPackageName)
           it.libraryName.set(extension.libraryName)
+
+          // We're reading the package.json at configuration time to properly feed
+          // the `jsRootDir` @Input property of this task. Therefore, the
+          // parsePackageJson should be invoked inside this lambda.
+          val packageJson = findPackageJsonFile(project, extension)
+          val parsedPackageJson = packageJson?.let { JsonUtils.fromCodegenJson(it) }
+
+          it.onlyIf { project.needsCodegenFromPackageJson(parsedPackageJson) }
         }
 
     // We add dependencies & generated sources to the project.
@@ -141,5 +152,29 @@ class ReactPlugin : Plugin<Project> {
 
       android.sourceSets.getByName("main").java.srcDir(File(generatedSrcDir, "java"))
     }
+  }
+
+  internal fun Project.needsCodegenFromPackageJson(model: ModelPackageJson?): Boolean {
+    /**
+    This flag allows us to codegen TurboModule bindings for only Discord modules. We need this differentiation because
+    React Native tooling only allows us to run TurboModule codegen if newArchEnabled=true, but the newArchEnabled flag
+    assumes a complete migration to the New Architecture. Third party libraries make codegen assumptions that
+    then break the build if we codegen, then build with newArchEnabled=false (things like codegen-ing TurboModule
+    classes that then share the same name as legacy module classes used when newArchEnabled=false).
+
+    The goal of this is to get us in a state where we can consume both TurboModules and legacy modules without having
+    to fully migrate to the new architecture.
+    */
+    var discordApproved = true
+    if (project.hasProperty("onlyDiscordTurboModulesEnabled")) {
+      discordApproved = model?.codegenConfig?.android?.javaPackageName?.startsWith("com.discord") == true
+    }
+
+    // Adding a log to see what packages are getting codegen'd
+    val willCodegen = discordApproved && model?.codegenConfig != null
+    if (willCodegen) {
+      println("Running codegen for package ${model?.codegenConfig?.android?.javaPackageName?.toString()}")
+    }
+    return willCodegen
   }
 }


### PR DESCRIPTION
**In This PR..**

Adding Support for building only Discord TurboModules.

### How It's Done

We accomplish in two parts (TL;DRs in bold)

1. **Adding an option in `ReactPlugin.kt` to codegen only modules with a package name starting with `com.discord`.** Codegen is the "third pillar" of "The New Architecture". It allows us to define the schema of what's communicated through the JSI, and have the Makefiles/Java/etc. generated for us, to the point where all we need to do is include and implement their generated interface on the native side, and call the generated interface from the JS side. The vanilla way to codegen is by running the `generateCodegenArtifactsFromSchema` gradle task with `newArchEnabled=true`, normally this task is added as part of the build when `newArchEnabled=true`, so it's not normally run standalone, though it can be. This task is problematic because some of our third party dependencies, like `react-native-reanimated` or `react-native-gesture-handler` have codegen support, and this task will codegen every module that has codegen support. If we run codegen, then run a build with `newArchEnabled=false`, it creates build issues with these third party dependencies because their generated schemas share the same class name as their legacy-module-schema equivalents, thus we get class name duplicate errors. The fix for this is to add in a new project level gradle option: `onlyDiscordTurboModulesEnabled`. This creates an extra condition during the codegen process to only codegen modules that begin with `com.discord`, we can then run (at the `react-native/ReactAndroid` level) `ORG_GRADLE_PROJECT_newArchEnabled=true ORG_GRADLE_PROJECT_onlyDiscordTurboModulesEnabled=true ./gradlew generateCodegenArtifactsFromSchema`. This runs the task with both `newArchEnabled` and `onlyDiscordTurboModulesEnabled` set to `true`, codegen-ing only Discord TurboModules.

2. **Adding extra options to the generated CMakeLists.txt to support libraries/headers needed to compile generated code with the JSI.** The JSI (javascript interface) is React Native's "new way" of communicating between javascript and native code synchronously, it's written in C++. The JSI is the alternative method of the "old way" of communicating between JS/native, via the JSON bridge asynchronously. When a module is codegen'd, it generates a `CMakeLists.txt` describing how to compile the generated `.h` and `.cpp` files, which are the JSI layer of the TurboModule. In order to compile against the JSI layer, we need a handful of libraries (`*.so`) and their associated headers. These resources are assumed to be available, but they aren't when compiling with `newArchEnabled=false`. These new options allow us to pass in a couple extra CMake options: `PREBUILT_CMAKE`, which is a `.cmake` file that includes library definitions for the needed JSI `*.so`s. `EXTRA_INCLUDE_DIRECTORIES`, which allows us to define an extra set of header directories, so the compiled source knows where `<fbjni/fbjni.h>` and all of the other includes are.

### Assumptions

**For the moment, we must build React Native from source if we're building out these Discord-only-TurboModules**. We can fix this in the future, but there's two versions of `react-native-codegen` in this repository. One in `packages/` for when building React Native from source, and one provided via yarn, which'll eventually end up in `node_modules`, for when providing a pre-built React Native artifact. This PR only includes the impl for the build-from-source approach while we stand up the initial Discord TurboModules. A future PR will provide the impl for the prebuilt approach.