### PR TITLE
[android] make promiseimpl's reject method thread safe

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/PromiseImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/PromiseImpl.java
@@ -165,7 +165,7 @@ public class PromiseImpl implements Promise {
    * @param userInfo WritableMap
    */
   @Override
-  public void reject(
+  public synchronized void reject(
       @Nullable String code,
       @Nullable String message,
       @Nullable Throwable throwable,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`PromiseImpl` is not thread-safe, causing crashes on accessing a variable that can become null on a different thread. This has been causing Discord's `BillingManagerModule` to throw `NullPointerException`s about 800-1k times each day (estimated with sentry sampling). 

Also see:
https://github.com/facebook/react-native/issues/35068 
https://app.asana.com/0/1202593986197760/1203652454773960
https://discord.sentry.io/issues/3504368273/?project=5992375

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Fixed] - Fixed PromiseImpl's reject not thread-safe

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
