### PR TITLE
Clamp `last` of cellsAroundViewport

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -870,7 +870,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
 
     return {
       first: clamp(0, cells.first, maxFirst),
-      last: Math.min(lastPossibleCellIndex, cells.last),
+      last: clamp(-1, cells.last, lastPossibleCellIndex),
     };
   }
 


### PR DESCRIPTION
Asana: https://app.asana.com/0/1199167684846005/1205213585978357

This PR cherry-picks the fix from origin react native repo and adds clamp for `last` prop so it won't be less than -1.