### PR TITLE
Fix: a11y crash when an accessible link is ellipsized away

### DIFF
--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
@@ -65,6 +65,20 @@ class AccessibilityAndroidExample extends React.Component<
   render(): React.Node {
     return (
       <RNTesterPage title={'Accessibility Android APIs'}>
+        <RNTesterBlock title="Ellipsized Accessible Links">
+          <Text numberOfLines={3}>
+            <Text>
+              Bacon {this.state.count} Ipsum{'\n'}
+            </Text>
+            <Text>Dolor sit amet{'\n'}</Text>
+            <Text>Eggsecetur{'\n'}</Text>
+            <Text>{'\n'}</Text>
+            <Text accessibilityRole="link" onPress={this._addOne}>
+              http://github.com
+            </Text>
+          </Text>
+        </RNTesterBlock>
+
         <RNTesterBlock title="LiveRegion">
           <TouchableWithoutFeedback onPress={this._addOne}>
             <View style={styles.embedded}>


### PR DESCRIPTION
A resubmission of #37 against our current branch 0.72.3-discord-1, since it seems the changes were lost