### PR TITLE
use boost tar on linux too

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -37,7 +37,7 @@ def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 def reactNativeRootDir = projectDir.parent
 
 // NOTE(flewp): We want CI machines to also expand a tarball instead of a zip.
-def needsBoostTar = Os.isFamily(Os.FAMILY_MAC) || System.getenv("CI")
+def needsBoostTar = Os.isFamily(Os.FAMILY_MAC) || Os.isFamily(Os.FAMILY_UNIX) || System.getenv("CI")
 def boostExtension = needsBoostTar ? ".tar.gz" : ".zip"
 
 // We put the publishing version from gradle.properties inside ext. so other


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


Fixes build on Linux / WSL.

Currently the build on linux is failing.

The error I get is:
```
1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':ReactNativeSource:prepareBoost'.
> Could not expand ZIP '/home/alex/dev/discord/discord_app/node_modules/react-native/ReactAndroid/build/downloads/boost_1_81_0.zip'.
```

Building with tracing I see:
```
Caused by: java.lang.IllegalArgumentException: 'boost_1_81_0/libs/json/test/parse-vectors/n_number_-1.0..json' is not a safe zip entry name.
        at org.gradle.util.internal.ZipSlip.safeZipEntryName(ZipSlip.java:37)
```


This seems to be a failure to unpack the boost zip due to gradle "ZipSlip" mitigations.  

Question: Do we still need the regular zip anywhere?

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] Use boost tar instead of zip on linux

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
I was able to successfully build discord for android "app-developer-release.apk" with this change in place