### PR TITLE
Revert "use boost tar on linux too"

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -37,7 +37,7 @@ def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 def reactNativeRootDir = projectDir.parent
 
 // NOTE(flewp): We want CI machines to also expand a tarball instead of a zip.
-def needsBoostTar = Os.isFamily(Os.FAMILY_MAC) || Os.isFamily(Os.FAMILY_UNIX) || System.getenv("CI")
+def needsBoostTar = Os.isFamily(Os.FAMILY_MAC) || System.getenv("CI")
 def boostExtension = needsBoostTar ? ".tar.gz" : ".zip"
 
 // We put the publishing version from gradle.properties inside ext. so other


### PR DESCRIPTION
The react-native-version-bump CI job seems to use the tar.gz after the commit in question,
which fails the build. The previous successful execution of the job used the zip. So it seems
like the `System.getenv("CI")` condition already present does not apply to that pipeline and
adding linux breaks it.

I'm shifting my focus to desktop for the time being and don't have the cycles to debug groovy
unpackers or CI, so I'm putting up a revert to unbreak the build.  

This reverts commit b98974f85f713956acd5aa1fd8afd48c34ecfa6d.

