### PR TITLE
NativeMeasurer for Android

### DIFF
--- a/Libraries/Animated/NativeFabricMeasurerTurboModule.js
+++ b/Libraries/Animated/NativeFabricMeasurerTurboModule.js
@@ -1,0 +1,30 @@
+import type {TurboModule} from '../TurboModule/RCTExport';
+import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
+
+type MeasureOnSuccessCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  pageX: number,
+  pageY: number,
+) => void;
+
+type MeasureInWindowOnSuccessCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+) => void;
+
+export interface Spec extends TurboModule {
+  +measureNatively: (viewTag: number, callback: MeasureOnSuccessCallback) => void,
+  +measureInWindowNatively: (
+    viewTag: number,
+    callback: MeasureInWindowOnSuccessCallback,
+  ) => void,
+}
+
+export default (TurboModuleRegistry.get<Spec>(
+  'NativeFabricMeasurerTurboModule',
+): ?Spec);

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeFabricMeasurerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeFabricMeasurerModule.java
@@ -1,0 +1,59 @@
+package com.facebook.react.animated;
+
+import android.util.Log;
+import android.view.View;
+
+import com.facebook.fbreact.specs.NativeFabricMeasurerTurboModuleSpec;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.UIManager;
+import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.uimanager.NativeViewMeasurer;
+import com.facebook.react.uimanager.PixelUtil;
+import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.uimanager.common.UIManagerType;
+
+@ReactModule(name = NativeFabricMeasurerTurboModuleSpec.NAME)
+public class NativeFabricMeasurerModule extends NativeFabricMeasurerTurboModuleSpec implements NativeViewMeasurer.ViewProvider {
+  private final NativeViewMeasurer measurer = new NativeViewMeasurer(this);
+
+  public NativeFabricMeasurerModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+  }
+
+  @Override
+  public void measureNatively(double viewTag, Callback callback) {
+    getReactApplicationContext().runOnUiQueueThread(() -> {
+      int[] output = measurer.measure((int) viewTag);
+      float x = PixelUtil.toDIPFromPixel(output[0]);
+      float y = PixelUtil.toDIPFromPixel(output[1]);
+      float width = PixelUtil.toDIPFromPixel(output[2]);
+      float height = PixelUtil.toDIPFromPixel(output[3]);
+      callback.invoke(0, 0, width, height, x, y);
+    });
+  }
+
+  @Override
+  public void measureInWindowNatively(double viewTag, Callback callback) {
+    getReactApplicationContext().runOnUiQueueThread(() -> {
+      int[] output = measurer.measureInWindow((int) viewTag);
+      float x = PixelUtil.toDIPFromPixel(output[0]);
+      float y = PixelUtil.toDIPFromPixel(output[1]);
+      float width = PixelUtil.toDIPFromPixel(output[2]);
+      float height = PixelUtil.toDIPFromPixel(output[3]);
+      callback.invoke(x, y, width, height);
+    });
+  }
+
+  @Override
+  public View provideView(int tag) {
+    UIManager uiManager = UIManagerHelper.getUIManager(getReactApplicationContext(), UIManagerType.FABRIC);
+    if (uiManager == null) {
+      return null;
+    }
+
+    return uiManager.resolveView(tag);
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -11,6 +11,7 @@ import androidx.annotation.Nullable;
 import com.facebook.react.TurboReactPackage;
 import com.facebook.react.ViewManagerOnDemandReactPackage;
 import com.facebook.react.animated.NativeAnimatedModule;
+import com.facebook.react.animated.NativeFabricMeasurerModule;
 import com.facebook.react.bridge.ModuleSpec;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -131,6 +132,8 @@ public class MainReactPackage extends TurboReactPackage implements ViewManagerOn
         return new IntentModule(context);
       case NativeAnimatedModule.NAME:
         return new NativeAnimatedModule(context);
+      case NativeFabricMeasurerModule.NAME:
+        return new NativeFabricMeasurerModule(context);
       case NetworkingModule.NAME:
         return new NetworkingModule(context);
       case PermissionsModule.NAME:
@@ -380,6 +383,7 @@ public class MainReactPackage extends TurboReactPackage implements ViewManagerOn
             ImageStoreManager.class,
             IntentModule.class,
             NativeAnimatedModule.class,
+            NativeFabricMeasurerModule.class,
             NetworkingModule.class,
             PermissionsModule.class,
             DevToolsSettingsManagerModule.class,

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewMeasurer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewMeasurer.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package com.facebook.react.uimanager;
+
+import android.graphics.Matrix;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.view.View;
+import android.view.ViewParent;
+
+import com.facebook.common.logging.FLog;
+import com.facebook.react.bridge.UiThreadUtil;
+
+public class NativeViewMeasurer {
+  public static final String TAG = "NativeViewMeasurer";
+  private final ViewProvider viewProvider;
+  public NativeViewMeasurer(ViewProvider viewProvider) {
+    this.viewProvider = viewProvider;
+  }
+
+  /**
+   * Returns true on success, false on failure. If successful, after calling, output buffer will be
+   * {x, y, width, height}.
+   */
+  public int[] measure(int tag) {
+    UiThreadUtil.assertOnUiThread();
+
+    int[] outputBuffer = {0, 0, 0, 0, 0, 0};
+    View v = viewProvider.provideView(tag);
+    if (v == null) {
+      FLog.w(TAG, "measure: No native view for " + tag + " currently exists");
+      return outputBuffer;
+    }
+
+    View rootView = (View) RootViewUtil.getRootView(v);
+    // It is possible that the RootView can't be found because this view is no longer on the screen
+    // and has been removed by clipping
+    if (rootView == null) {
+      FLog.w(TAG, "measure: Native view " + tag + " is no longer on screen");
+      return outputBuffer;
+    }
+
+    computeBoundingBox(rootView, outputBuffer);
+    int rootX = outputBuffer[0];
+    int rootY = outputBuffer[1];
+    computeBoundingBox(v, outputBuffer);
+    outputBuffer[0] -= rootX;
+    outputBuffer[1] -= rootY;
+    return outputBuffer;
+  }
+
+  /**
+   * Returns the coordinates of a view relative to the window (not just the RootView which is what
+   * measure will return)
+   *
+   * @param tag - the tag for the view
+   */
+  public int[] measureInWindow(int tag) {
+    UiThreadUtil.assertOnUiThread();
+    View v = viewProvider.provideView(tag);
+    int[] outputBuffer = {0, 0, 0, 0};
+    if (v == null) {
+      FLog.w(TAG, "measureInWindow: No native view for " + tag + " currently exists");
+      return outputBuffer;
+    }
+
+    int[] locationOutputBuffer = new int[2];
+    v.getLocationOnScreen(locationOutputBuffer);
+
+    // we need to subtract visibleWindowCoords - to subtract possible window insets, split screen or
+    // multi window
+    Rect visibleWindowFrame = new Rect();
+    v.getWindowVisibleDisplayFrame(visibleWindowFrame);
+    outputBuffer[0] = locationOutputBuffer[0] - visibleWindowFrame.left;
+    outputBuffer[1] = locationOutputBuffer[1] - visibleWindowFrame.top;
+
+    // outputBuffer[0,1] already contain what we want
+    outputBuffer[2] = v.getWidth();
+    outputBuffer[3] = v.getHeight();
+    return outputBuffer;
+  }
+
+  private void computeBoundingBox(View view, int[] outputBuffer) {
+    RectF boundingBox = new RectF(0, 0, view.getWidth(), view.getHeight());
+    boundingBox.set(0, 0, view.getWidth(), view.getHeight());
+    mapRectFromViewToWindowCoords(view, boundingBox);
+
+    outputBuffer[0] = Math.round(boundingBox.left);
+    outputBuffer[1] = Math.round(boundingBox.top);
+    outputBuffer[2] = Math.round(boundingBox.right - boundingBox.left);
+    outputBuffer[3] = Math.round(boundingBox.bottom - boundingBox.top);
+    outputBuffer[4] = Math.round(view.getLeft());
+    outputBuffer[5] = Math.round(view.getTop());
+  }
+
+  private void mapRectFromViewToWindowCoords(View view, RectF rect) {
+    Matrix matrix = view.getMatrix();
+    if (!matrix.isIdentity()) {
+      matrix.mapRect(rect);
+    }
+
+    rect.offset(view.getLeft(), view.getTop());
+
+    ViewParent parent = view.getParent();
+    while (parent instanceof View) {
+      View parentView = (View) parent;
+
+      rect.offset(-parentView.getScrollX(), -parentView.getScrollY());
+
+      matrix = parentView.getMatrix();
+      if (!matrix.isIdentity()) {
+        matrix.mapRect(rect);
+      }
+
+      rect.offset(parentView.getLeft(), parentView.getTop());
+
+      parent = parentView.getParent();
+    }
+  }
+
+
+  public interface ViewProvider {
+    View provideView(int tag);
+  }
+}
+

--- a/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -576,6 +576,22 @@ jsi::Value UIManagerBinding::get(
             jsi::Value const *arguments,
             size_t /*count*/) noexcept -> jsi::Value {
           auto shadowNode = shadowNodeFromValue(runtime, arguments[0]);
+          bool turboModuleCalled = false;
+          auto nativeMeasurerValue = runtime.global().getProperty(runtime, "__turboModuleProxy")
+                  .asObject(runtime).asFunction(runtime).call(runtime, "NativeFabricMeasurerTurboModule");
+
+          if (nativeMeasurerValue.isObject()) {
+              // This calls measureNatively if the NativeFabricMeasurerTurboModule is found.
+              // The return value doesn't matter here because the measure values will be passed through the callback.
+              jsi::Value returnValue = nativeMeasurerValue.asObject(runtime).getPropertyAsFunction(runtime, "measureNatively")
+                      .call(runtime, shadowNode.get()->getTag(), arguments[1].getObject(runtime).getFunction(runtime));
+              turboModuleCalled = true;
+          }
+
+          if (turboModuleCalled) {
+              return jsi::Value::undefined();
+          }
+          
           auto layoutMetrics = uiManager->getRelativeLayoutMetrics(
               *shadowNode, nullptr, {/* .includeTransform = */ true});
           auto onSuccessFunction =
@@ -617,8 +633,25 @@ jsi::Value UIManagerBinding::get(
             jsi::Value const & /*thisValue*/,
             jsi::Value const *arguments,
             size_t /*count*/) noexcept -> jsi::Value {
+          auto shadowNode = shadowNodeFromValue(runtime, arguments[0]);
+          bool turboModuleCalled = false;
+          auto nativeMeasurerValue = runtime.global().getProperty(runtime, "__turboModuleProxy")
+                  .asObject(runtime).asFunction(runtime).call(runtime, "NativeFabricMeasurerTurboModule");
+
+          if (nativeMeasurerValue.isObject()) {
+              // This calls measureNatively if the NativeFabricMeasurerTurboModule is found.
+              // The return value doesn't matter here because the measure values will be passed through the callback.
+              jsi::Value returnValue = nativeMeasurerValue.asObject(runtime).getPropertyAsFunction(runtime, "measureInWindowNatively")
+                      .call(runtime, shadowNode.get()->getTag(), arguments[1].getObject(runtime).getFunction(runtime));
+              turboModuleCalled = true;
+          }
+
+          if (turboModuleCalled) {
+              return jsi::Value::undefined();
+          }
+            
           auto layoutMetrics = uiManager->getRelativeLayoutMetrics(
-              *shadowNodeFromValue(runtime, arguments[0]),
+              *shadowNode,
               nullptr,
               {/* .includeTransform = */ true,
                /* .includeViewportOffset = */ true});


### PR DESCRIPTION
**In This PR..**

A fix for measuring native views in Fabric.

## Background

#### The Shadow Tree 

Starting in Fabric, React Native has a "Shadow Tree". Its state is kept in C++. The Shadow Tree is the Native representation of React's JS component tree. The Shadow Tree differs from React's JS component tree in two main ways.

1) The Shadow tree only contains the components that reduce to actual Native views. For example, if you had a
`<MyCoolComponent style={...}><View /></MyCoolComponent>` in JS,
the Shadow Tree would only contain `View` because `MyCoolComponent` does not have a Native representation (unless you added a native `ViewManager` for `MyCoolComponent` and registered that natively ahead of time, but we're assuming here the only reference to `MyCoolComponent` is in JS).
2) The Shadow Tree contains every view's layout information (provided by [Yoga](https://yogalayout.com/)). This includes the x/y coordinates and width/height. Importantly to this issue, this layout information is provided/updated every time a new version of the Shadow Tree is "committed" (usually "commits" are kicked off after React's reconciliation process). [This doc is incredibly helpful related reading for the commit process.](https://reactnative.dev/architecture/render-pipeline).

#### React Native's `View.Animated`

React Native provides an [`Animated` API](https://reactnative.dev/docs/next/animations). Its purpose is to be able to provide smooth animations defined in JS for components ultimately rendered on the Native side. Because historically React Native's JS and Native communication happened via the "JSON bridge" asynchronously, there wasn't a performant way to pipe an event reliably every frame to smoothly animate views, so they developed a way to directly manipulate a view's layout parameters, bypassng React's rendering commit/layout pipeline. 

In the Paper renderer (a.k.a. the "Old Architecture"), React was able to get away with its Animated API bypassing the render pipeline because Paper's equivalent of the "Shadow Tree" was literally just the native `View` tree. As in, when React wanted to get a Native `View`'s measurement from the JS side, the Native side's implementation would start at the `View` in question, walk up through each parent until it found a `View` that had the type `RootView`, then walk back down the children `View`s until it got to the original `View`, applying all the parent `View` offsets along the way. All that is to say, the `View`s could be updated via React's rendering pipeline, or directly manipulated through the `Animated` API, and it didn't matter because the Native `View` tree was the source of truth.

## The Problem

In the Fabric renderer (a.k.a. the "New Architecture"), the JS side now considers the Native source of truth to be the "Shadow Tree". As in, when the JS side wants to measure a `View`, it only goes to check the Shadow Tree's layout information. As far as the Native side is concerned, it no longer directly services measurement requests. Unfortunately, React Native's `Animated` API still bypasses the React renderer, so any layout updates applied by the `Animated` API never get committed to the Shadow Tree. This becomes problematic when a view needs to be measured from the JS side. Probably the easiest example to illustrate for this is React Native's pressability architecture. When a press gesture is being processed, the logic measures the native view so it can check if touch events stay within the native view's bounds. If the native view has been manipulated by React Native's `Animated` API in any way, those manipulated properties aren't reflected in the Shadow Tree and so the views on the screen aren't necessarily where the Shadow Tree thinks they are. So when the JS side checks the Shadow Tree and sees that the touch event is not within the bounds of the view (even though it looks like it is on the phone's screen), it cancels the press event. 

A fairly straightforward upshot: any place in JS that uses `UIManager.measure` or `UIManager.measureInWindow` is at risk of being reported incorrect measurements from the Shadow Tree when on Fabric.

Here are some related discussion threads where others are finding similar issues. 
https://github.com/facebook/react-native/issues/36504
https://github.com/facebook/react-native/issues/36710

Here's a couple places that we've seen `Animated` APIs:
- In the `Navigator` because `react-native-screens` animates each screen in a `Navigator` directly with `Animated`.
- In Alerts
- In ScrollViews

## The Fix

Both the `Animated` API and `UIManager.measure*` are used within React Native itself and several third party dependencies. Therefore, my initial approach here is to create a TurboModule that implements a retrofitted version of Paper's measure logic using a bit of Fabric's UI Manager on the native side, and polyfill the measure methods on the JS side to hopefully manipulate all `measure*` calls to funnel into the proper measure logic.

## Related Reading

- Seriously, [this is a great doc for the React Native's rendering pipeline](https://reactnative.dev/architecture/render-pipeline).
- [The measure call where the Pressability logic fails in JS.](https://github.com/facebook/react-native/blob/24b682081b79a05fd25587c29430e758658f7754/packages/react-native/Libraries/Pressability/Pressability.js#L815)
- [Fabric's C++ implementation of `measure`. `getRelativeLayoutMetrics` calls into the Shadow Tree.](https://github.com/facebook/react-native/blob/24b682081b79a05fd25587c29430e758658f7754/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp#L579)
- [Paper's native side of `measure` and the `NativeViewHierarchyManager`. Notice how it's just walking up Android's `View` tree. This is what this PR's TurboModule is inspired by.](https://github.com/facebook/react-native/blob/24b682081b79a05fd25587c29430e758658f7754/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java#L682)
- [The `SurfaceMountingManager`, which is how Fabric manipulates the Native View tree.](https://github.com/facebook/react-native/blob/24b682081b79a05fd25587c29430e758658f7754/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java#L62) It's basically the equivalent of Paper's `NativeHierarchyManager`. With Paper, the `NativeHierarchyManager` has much more information passed to it. Now in Fabric, the `SurfaceMountingManager` is passed essentially minimal diffs offered by the Shadow Tree.
- [An alternate approach to this problem in React Native's codebase. Specifically `Animated` provides an escape hatch prop. See how `passthroughAnimatedPropExplicitValues` is formed.](https://github.com/facebook/react-native/blob/24b682081b79a05fd25587c29430e758658f7754/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js#L120-L133) This approach probably wouldn't work for us because it basically runs that prop through the JS's render loop, causing lag even with Fabric.
- [How Reanimated works at the C++ level.](https://github.com/software-mansion/react-native-reanimated/blob/c411c45da27246133f80b75e5b52a54e91393453/Common/cpp/NativeModules/NativeReanimatedModule.cpp#L462). This function is a great place to start for going forward through the Shadow Tree manipulation to the Native side in the `SurfaceMountingManager`, or backward up to JS to the `useAnimatedStyle` hook. Reanimated is able to performantly run animations directly through manipulating the Shadow Tree. This allows animations serviced by Reanimated to not be affected by this problem.

### Testing Plan

I've tested that this fixes pressable surfaces on Fabric devices. Also tested that this fix doesn't regress things on Fabric.