### PR TITLE
Fix incorrect values for modal sizing

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -489,10 +489,21 @@ public class ReactModalHostView extends ViewGroup
       }
     }
 
+    /**
+     * Updates the shadow tree via the local fabric view state manager. Can noop if the same values
+     * are passed multiple times. Can also ignore params if the local variables for viewWidth &
+     * viewHeight are non-zero.
+     *
+     * @param width target width of the container as pixels. Will be converted to DIP.
+     * @param height target height of the container as pixels. Will be converted to DIP.
+     */
     @UiThread
     public void updateState(final int width, final int height) {
-      final float realWidth = PixelUtil.toDIPFromPixel(width);
-      final float realHeight = PixelUtil.toDIPFromPixel(height);
+      // Once viewWidth & viewHeight are set by an onSizeChanged callback they become our source
+      // of truth. This makes the fabric renderer function like the paper renderer is currently
+      // functioning.
+      final float realWidth = PixelUtil.toDIPFromPixel((viewWidth > 0) ? viewWidth : width);
+      final float realHeight = PixelUtil.toDIPFromPixel((viewHeight > 0) ? viewHeight : height);
 
       // Check incoming state values. If they're already the correct value, return early to prevent
       // infinite UpdateState/SetState loop.


### PR DESCRIPTION

![Screenshot_20230920-145352_1](https://github.com/discord/react-native/assets/1414515/3b76d507-5276-4c35-8b1b-d7c3165661e2)

# Final Writeup - Incorrect modal sizing
Why is this broken, tldr? Both paper and fabric start with the wrong value from ModalHostHelper, and both get on size changed callbacks from the android OS for the view with correct sizing. Paper uses this and the size becomes the source of truth & is reflected in the shadow tree. Fabric sets the state on the shadow tree which triggers an update state callback (specific to fabric) which then gets the wrong size from modal host helper again and overwrites the correct size.

### Possible fixes
1. Delete modal host helper (like the pr from sw mansion engineer). Causes freezes deep in fabric renderer caused by views starting with zero size. This bug was mistakenly introduced by fb fixing this. ❌
2. Update ModalHostHelper to return the correct sizes. This file hasn't changed in 4 years and is easier said than done. We're basically rewriting what the inner workings of android windows are doing to stretch fullscreen factoring in the status bar & bottom software navbar as well as window multitasking & landscape orientation a bunch of edge cases here that it feels particularly gnarly to try to implement. ❌
3. Updated ReactModalHostView to treat the cached width/height from OS generated on size changes and use those as the exclusive source of truth once they're set. This'll make fabric work like paper currently works starting with the wrong value initially and then getting corrected by the cached values.  There are multiple locations we could pick from to do this check in code. ✅

### Fix considerations
We could fix this at the call-site or the implementation. I opted for the implementation. Fixing at the call-site would violate tell don't ask and callers would need to check if this views internal state before calling `updateState()`. The caller is this view's view manager so they're extremely tightly coupled, but it still felt gross to do this at the call-site. Fixing in the implementation results in a relatively ambiguous function that might ignore the parameters you pass in due to internal state. I added a doc comment to explain what might happen. Ultimately i'd like to see this deleted in favor of an eventual fix from upstream.
