### PR TITLE
support websocket raw length

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -245,7 +245,8 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
             data = BlobManager.createFromOptions(ev.data);
             break;
         }
-        this.dispatchEvent(new WebSocketEvent('message', {data}));
+        const raw_length = ev.raw_length;
+        this.dispatchEvent(new WebSocketEvent('message', {data, raw_length}));
       }),
       this._eventEmitter.addListener('websocketOpen', ev => {
         if (ev.id !== this._socketId) {


### PR DESCRIPTION
This adds an extra 'raw_length' field to WebSocketEvent that propagates it from the webSocketMessage from the underlying websocket implementation. It is intended to be used to measure the compressed size of the payload.