### PR TITLE
Avoid using Xcode 15's gcc when compiling glog

### DIFF
--- a/scripts/ios-configure-glog.sh
+++ b/scripts/ios-configure-glog.sh
@@ -42,8 +42,8 @@ EOF
     patch -p1 config.sub fix_glog_0.3.5_apple_silicon.patch
 fi
 
-export CC="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
-export CXX="$CC"
+# export CC="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
+# export CXX="$CC"
 
 # Remove automake symlink if it exists
 if [ -h "test-driver" ]; then


### PR DESCRIPTION
Xcode 15's version of gcc seems to break the build of `glog` (a dependency of React Native). Since we run `pod install` inside of a Nix shell, though, I feel pretty safe falling back to the environment's gcc (rather than using Xcode's). 

I can only assume that RN was doing this to try to make the compilation more hermetic, but we are already wrapping it in a hermetic environment.