### PR TITLE
update Text to support gradient colors

### DIFF
--- a/packages/react-native/Libraries/Text/BaseText/RCTBaseTextViewManager.mm
+++ b/packages/react-native/Libraries/Text/BaseText/RCTBaseTextViewManager.mm
@@ -28,6 +28,7 @@ RCT_EXPORT_MODULE(RCTBaseText)
 // Color
 RCT_REMAP_SHADOW_PROPERTY(color, textAttributes.foregroundColor, UIColor)
 RCT_REMAP_SHADOW_PROPERTY(backgroundColor, textAttributes.backgroundColor, UIColor)
+RCT_REMAP_SHADOW_PROPERTY(gradientColors, textAttributes.gradientColors, NSArray)
 RCT_REMAP_SHADOW_PROPERTY(opacity, textAttributes.opacity, CGFloat)
 // Font
 RCT_REMAP_SHADOW_PROPERTY(fontFamily, textAttributes.fontFamily, NSString)

--- a/packages/react-native/Libraries/Text/RCTTextAttributes.h
+++ b/packages/react-native/Libraries/Text/RCTTextAttributes.h
@@ -27,6 +27,7 @@ extern NSString *const RCTTextAttributesTagAttributeName;
 // Color
 @property (nonatomic, strong, nullable) UIColor *foregroundColor;
 @property (nonatomic, strong, nullable) UIColor *backgroundColor;
+@property (nonatomic, copy, nullable) NSArray *gradientColors;
 @property (nonatomic, assign) CGFloat opacity;
 // Font
 @property (nonatomic, copy, nullable) NSString *fontFamily;

--- a/packages/react-native/Libraries/Text/Text.d.ts
+++ b/packages/react-native/Libraries/Text/Text.d.ts
@@ -210,6 +210,9 @@ export interface TextProps
    */
   minimumFontScale?: number | undefined;
 
+  /**
+   * Adds a horizontal gradient using the int based color values.
+   */
   gradientColors?: number[] | undefined;
 }
 

--- a/packages/react-native/Libraries/Text/Text.d.ts
+++ b/packages/react-native/Libraries/Text/Text.d.ts
@@ -209,6 +209,8 @@ export interface TextProps
    * Specifies smallest possible scale a font can reach when adjustsFontSizeToFit is enabled. (values 0.01-1.0).
    */
   minimumFontScale?: number | undefined;
+
+  gradientColors?: number[] | undefined;
 }
 
 /**

--- a/packages/react-native/Libraries/Text/TextNativeComponent.js
+++ b/packages/react-native/Libraries/Text/TextNativeComponent.js
@@ -49,6 +49,7 @@ const textViewConfig = {
     dataDetectorType: true,
     android_hyphenationFrequency: true,
     lineBreakStrategyIOS: true,
+    gradientColors: true,
   },
   directEventTypes: {
     topTextLayout: {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -162,8 +162,8 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
     }
     int end = sb.length();
     if (end >= start) {
-      if (textShadowNode.mIsColorSet || textShadowNode.mGradientColors.length >= 2) {
-        if (textShadowNode.mGradientColors.length >= 2) {
+      if (textShadowNode.mIsColorSet || textShadowNode.mGradientColors != null) {
+        if (textShadowNode.mGradientColors != null && textShadowNode.mGradientColors.length >= 2) {
           int effectiveFontSize = textAttributes.getEffectiveFontSize();
           ops.add(
                   new SetSpanOperation(start, end, new LinearGradientSpan(start * effectiveFontSize, textShadowNode.mGradientColors)));
@@ -327,7 +327,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
   protected boolean mIsBackgroundColorSet = false;
   protected int mBackgroundColor;
 
-  protected int[] mGradientColors = new int[0];
+  protected @Nullable int[] mGradientColors = null;
 
   protected @Nullable AccessibilityRole mAccessibilityRole = null;
   protected @Nullable Role mRole = null;
@@ -500,10 +500,15 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
           colors.add(color);
         }
       }
-      if (colors.size() >= 2) {
-        mGradientColors = colors.stream()
-          .mapToInt(Integer::intValue)
-          .toArray();
+
+      int colorsSize = colors.size();
+      if (colorsSize >= 2) {
+        int[] colorsAsList = new int[colorsSize];
+        for (int i = 0; i < colorsSize; i++) {
+            colorsAsList[i] = colors.get(i);
+        }
+
+        mGradientColors = colorsAsList;
       }
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/LinearGradientSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/LinearGradientSpan.kt
@@ -1,0 +1,27 @@
+package com.facebook.react.views.text.internal.span
+
+import android.graphics.LinearGradient
+import android.graphics.Shader
+import android.text.TextPaint
+import android.text.style.CharacterStyle
+import android.text.style.UpdateAppearance
+
+public class LinearGradientSpan(
+    private val start: Float,
+    private val colors: IntArray,
+) : CharacterStyle(), ReactSpan,
+    UpdateAppearance {
+    public override fun updateDrawState(tp: TextPaint) {
+        val textShader: Shader =
+            LinearGradient(
+                start,
+                0f,
+                start + 150.0f,
+                0f,
+                colors,
+                null,
+                Shader.TileMode.MIRROR,
+            )
+        tp.setShader(textShader)
+    }
+}


### PR DESCRIPTION
## Summary:

We added a new Boost perk called "Enhanced Role Colors/Styles" that allows admins to set gradient colors for roles in their guild. To support this on mobile, we have to provide native components that can render gradients.

At first, we were planning to create a custom native component but ran into 2 issues:
1. The custom component [needed a `height` and `width`](https://canary.discord.com/channels/281683040739262465/1352018048835522743/1354224981629866106) defined for it to render. This was fixed by [using a `ShadowNode`](https://canary.discord.com/channels/281683040739262465/1352018048835522743/1354474720615207152) but we ran into other sizing issues.
2. Our string formatter [nests `Text` nodes](https://canary.discord.com/channels/281683040739262465/1352018048835522743/1355183603725762752) and wouldn't render our custom view even when it extended `BaseText`.

We decided rather than creating a new custom component and solving for the above issues, it'd be easier to update `Text` to support gradient colors.

## Changelog:
- updates iOS and Android `Text` to support `gradientColors` which is an optional array of `number`s

## Test Plan:

Tested updating `ChatInputReplyBar` to show gradient colors with the following test cases:
- `gradientColors` with a list of `number`s
- `gradientColors` with some `null` values
- `gradientColors` with some `string` values
- `gradientColors` with some `double` values

For the value types not `int`, the goal is to not crash the app. This equates to different behaviors between the platforms but the dev will get a type error on the React JS side of things so things should generally work as expected.

I picked `ChatInputReplyBar` because it demonstrates the behavior with nested `Text` nodes and is a place where we will want to render gradient colors.

### screenshots
**happy path**
![image](https://github.com/user-attachments/assets/adf0a337-59a1-49bf-9cec-aa3ed0c963ce)

**`tertiaryColor` is `string` (which is ignored so only first 2 colors show)**
![image](https://github.com/user-attachments/assets/0b81c550-2fcc-4356-9cb0-8428c40ecc19)

**`tertiaryColor` is `double` (which is translated as `0` on Android and some other number on iOS)**
![image](https://github.com/user-attachments/assets/0ac55b67-d8a6-4a36-a573-217cab1db84e)
