### PR TITLE
update Text gradient colors to be mirrored on ios

### DIFF
--- a/packages/react-native/Libraries/Text/RCTTextAttributes.mm
+++ b/packages/react-native/Libraries/Text/RCTTextAttributes.mm
@@ -305,6 +305,7 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
       }
       
       if([cgColors count] > 0) {
+          [cgColors addObject:cgColors[0]];
           CAGradientLayer *gradient = [CAGradientLayer layer];
           // this pattern width corresponds roughly to desktop's pattern width
           int patternWidth = 100;


### PR DESCRIPTION
## Summary:

When we added gradient colors to `Text` in https://github.com/discord/react-native/pull/54, we forgot to duplicate the first color to create a mirrored pattern. Without the duplicated first color, the color transitions abruptly from the last color back to the first color.

## Changelog:

- duplicate first color when we create gradient color for `Text`

## Test Plan:

- Tested the chat input context bar which is the only component actively using this gradient

### before
![image](https://github.com/user-attachments/assets/b602e432-1cf4-4d15-b12c-a4e27a6c21f6)

### after
![image](https://github.com/user-attachments/assets/25bca312-5ae5-4b48-ab9b-ed454bcf7148)