### PR TITLE
fix android gradient colors faded

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -162,15 +162,12 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
     }
     int end = sb.length();
     if (end >= start) {
-      if (textShadowNode.mIsColorSet || textShadowNode.mGradientColors != null) {
-        if (textShadowNode.mGradientColors != null && textShadowNode.mGradientColors.length >= 2) {
+      if (textShadowNode.mIsColorSet) {
+        ops.add(new SetSpanOperation(start, end, new ReactForegroundColorSpan(textShadowNode.mColor)));
+      }
+      if (textShadowNode.mGradientColors != null && textShadowNode.mGradientColors.length >= 2) {
           int effectiveFontSize = textAttributes.getEffectiveFontSize();
-          ops.add(
-                  new SetSpanOperation(start, end, new LinearGradientSpan(start * effectiveFontSize, textShadowNode.mGradientColors)));
-        } else {
-          ops.add(
-                  new SetSpanOperation(start, end, new ReactForegroundColorSpan(textShadowNode.mColor)));
-        }
+          ops.add(new SetSpanOperation(start, end, new LinearGradientSpan(start * effectiveFontSize, textShadowNode.mGradientColors)));
       }
       if (textShadowNode.mIsBackgroundColorSet) {
         ops.add(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/LinearGradientSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/LinearGradientSpan.kt
@@ -12,6 +12,9 @@ public class LinearGradientSpan(
 ) : CharacterStyle(), ReactSpan,
     UpdateAppearance {
     public override fun updateDrawState(tp: TextPaint) {
+        // without setting the paint color, the gradient appears "faded" if no foreground color span is also applied
+        // https://stackoverflow.com/a/52289927
+        tp.setColor(colors[0])
         val textShader: Shader =
             LinearGradient(
                 start,


### PR DESCRIPTION
## Summary:

This PR fixes gradient colors on text appearing "faded". The *exact* reason isn't known but I found this [relevant stackoverflow answer](https://stackoverflow.com/a/52289927) and testing out the change shows that it works.

## Changelog:
- updated span operation logic to set a color span *and* a gradient color span if both are passed in (though visually the gradient color span takes precedence since it updates the shader itself)
- updated `LinearGradientSpan` to call `setColor` on the first color too -> this is needed when a color isn't set such as when `color="none"` is passed from the React JS side

## Test Plan:
- tested guild member list
- tested setting a random `Text` component with gradient colors

### screenshots
**Guild member list**
_before_
![image](https://github.com/user-attachments/assets/5ec8f93d-871d-478f-802d-4b71c6726976)

_after_
![image](https://github.com/user-attachments/assets/f2ec4849-6dbf-46b2-8f92-5f2bd4fc27a5)

**Thread title**
_before_
![image](https://github.com/user-attachments/assets/ee322aee-45ca-4924-a65f-e522af66c8c3)

_after_
![image](https://github.com/user-attachments/assets/0d9a3a55-be0d-4f17-9ab4-a79c6ae17175)
