### PR TITLE
new arch rn078 fixes

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -51,6 +51,11 @@ public object DefaultNewArchitectureEntryPoint {
               bridgelessEnabled || fabricEnabled
 
           override fun useTurboModules(): Boolean = bridgelessEnabled || turboModulesEnabled
+
+          // Fixes reanimated flickering issues where shadow node updates on the UI thread wouldn't be
+          // propagated back to the react JS fiber node/tree.
+          override fun useRuntimeShadowNodeReferenceUpdate(): Boolean =
+              bridgelessEnabled || turboModulesEnabled
         })
 
     privateFabricEnabled = fabricEnabled

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -308,14 +308,19 @@ void ShadowNode::setRuntimeShadowNodeReference(
   runtimeShadowNodeReference_ = runtimeShadowNodeReference;
 }
 
+void ShadowNode::updateRuntimeShadowNodeReference(
+    const Shared& destinationShadowNode) const {
+  if (auto reference = runtimeShadowNodeReference_.lock()) {
+    reference->shadowNode = destinationShadowNode;
+  }
+}
+
 void ShadowNode::transferRuntimeShadowNodeReference(
     const Shared& destinationShadowNode) const {
   destinationShadowNode->runtimeShadowNodeReference_ =
       runtimeShadowNodeReference_;
 
-  if (auto reference = runtimeShadowNodeReference_.lock()) {
-    reference->shadowNode = destinationShadowNode;
-  }
+  updateRuntimeShadowNodeReference(destinationShadowNode);
 }
 
 void ShadowNode::transferRuntimeShadowNodeReference(

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -320,7 +320,7 @@ void ShadowNode::transferRuntimeShadowNodeReference(
   destinationShadowNode->runtimeShadowNodeReference_ =
       runtimeShadowNodeReference_;
 
-  if (!ReactNativeFeatureFlags::updateRuntimeShadowNodeReferencesOnCommit()) {
+  if (!ReactNativeFeatureFlags::useRuntimeShadowNodeReferenceUpdate()) {
     updateRuntimeShadowNodeReference(destinationShadowNode);
   }
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -320,7 +320,9 @@ void ShadowNode::transferRuntimeShadowNodeReference(
   destinationShadowNode->runtimeShadowNodeReference_ =
       runtimeShadowNodeReference_;
 
-  updateRuntimeShadowNodeReference(destinationShadowNode);
+  if (!ReactNativeFeatureFlags::updateRuntimeShadowNodeReferencesOnCommit()) {
+    updateRuntimeShadowNodeReference(destinationShadowNode);
+  }
 }
 
 void ShadowNode::transferRuntimeShadowNodeReference(

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -188,6 +188,12 @@ class ShadowNode : public Sealable,
                                          runtimeShadowNodeReference) const;
 
   /*
+   * Update the runtime reference to point to the provided shadow node.
+   */
+  void updateRuntimeShadowNodeReference(
+      const Shared& destinationShadowNode) const;
+
+  /*
    * Transfer the runtime reference to this `ShadowNode` to a new instance,
    * updating the reference to point to the new `ShadowNode` referencing it.
    */

--- a/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.cpp
@@ -7,6 +7,8 @@
 
 #include "updateMountedFlag.h"
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
+
 namespace facebook::react {
 void updateMountedFlag(
     const ShadowNode::ListOfShared& oldChildren,
@@ -46,6 +48,10 @@ void updateMountedFlag(
 
     newChild->setMounted(true);
     oldChild->setMounted(false);
+
+    if (ReactNativeFeatureFlags::updateRuntimeShadowNodeReferencesOnCommit()) {
+      newChild->updateRuntimeShadowNodeReference(newChild);
+    }
 
     updateMountedFlag(oldChild->getChildren(), newChild->getChildren());
   }

--- a/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.cpp
@@ -49,7 +49,7 @@ void updateMountedFlag(
     newChild->setMounted(true);
     oldChild->setMounted(false);
 
-    if (ReactNativeFeatureFlags::updateRuntimeShadowNodeReferencesOnCommit()) {
+    if (ReactNativeFeatureFlags::useRuntimeShadowNodeReferenceUpdate()) {
       newChild->updateRuntimeShadowNodeReference(newChild);
     }
 


### PR DESCRIPTION
We merged RN 0.78 into the upgrade/new-arch branch.

We need to enable react shadow node runtime updates (RSNRU) to avoid inconsistencies between the JS react fiber tree and the shadow tree on the UI thread.