### PR TITLE
patch ReactModalHostview to init with correct sizes

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
@@ -14,7 +14,10 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB rrc_modal_SRC CONFIGURE_DEPENDS *.cpp)
+file(GLOB rrc_modal_SRC CONFIGURE_DEPENDS
+        *.cpp
+        platform/android/*.cpp)
+
 add_library(rrc_modal STATIC ${rrc_modal_SRC})
 
 target_include_directories(rrc_modal PUBLIC ${REACT_COMMON_DIR})

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
@@ -9,14 +9,13 @@
 
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/graphics/Float.h>
+#include "ModalHostViewUtils.h"
 
 #ifdef ANDROID
 #include <folly/dynamic.h>
 #endif
 
-#if defined(__APPLE__) && TARGET_OS_IOS
 #include "ModalHostViewUtils.h"
-#endif
 
 namespace facebook::react {
 
@@ -27,12 +26,7 @@ class ModalHostViewState final {
  public:
   using Shared = std::shared_ptr<const ModalHostViewState>;
 
-#if defined(__APPLE__) && TARGET_OS_IOS
-  ModalHostViewState() : screenSize(RCTModalHostViewScreenSize()) {
-#else
-  ModalHostViewState(){
-#endif
-  };
+  ModalHostViewState() : screenSize(RCTModalHostViewScreenSize()) {}
   ModalHostViewState(Size screenSize_) : screenSize(screenSize_){};
 
 #ifdef ANDROID
@@ -54,3 +48,4 @@ class ModalHostViewState final {
 };
 
 } // namespace facebook::react
+

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/platform/android/JReactModalHostView.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/platform/android/JReactModalHostView.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <react/renderer/graphics/Size.h>
+
+#include <android/log.h>
+
+namespace facebook::react {
+
+class JReactModalHostView
+    : public facebook::jni::JavaClass<JReactModalHostView> {
+ public:
+  static auto constexpr kJavaDescriptor =
+      "Lcom/facebook/react/views/modal/ReactModalHostView;";
+
+  static Size getDisplayMetrics() {
+    static auto method = JReactModalHostView::javaClassStatic()
+                             ->getStaticMethod<jni::JArrayFloat()>(
+                                 "getScreenDisplayMetricsWithoutInsets");
+    auto result = method(javaClassStatic());
+    size_t size = result->size();
+    std::vector<jfloat> elements(size + 1L);
+    result->getRegion(0, size, elements.data());
+    return Size{elements[0], elements[1]};
+  }
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/platform/android/ModalHostViewUtils.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/platform/android/ModalHostViewUtils.cpp
@@ -5,12 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#pragma once
-
-#include <react/renderer/graphics/Size.h>
+#include <react/renderer/components/modal/ModalHostViewUtils.h>
+#include "JReactModalHostView.h"
 
 namespace facebook::react {
 
-Size RCTModalHostViewScreenSize(void);
+Size RCTModalHostViewScreenSize(void) {
+  return JReactModalHostView::getDisplayMetrics();
+}
 
 } // namespace facebook::react


### PR DESCRIPTION
This fixes a frozen UI bug caused by the Modal's broken layout. We are pulling a [soon to land patch](https://github.com/facebook/react-native/pull/51048/files) in the React Native core repo. Once we upgrade to a version that includes this patch this will naturally merge.

| Before | After |
|--|--|
| <video width="300" src="https://github.com/user-attachments/assets/a0c1876a-eaf4-4ae7-8ce9-a5bbe6cbd596" /> |  <video width="300" src="https://github.com/user-attachments/assets/f841d3de-d906-44dc-b138-66c084ceaf35" />  |


| Before | After |
|--|--|
| <video width="300" src="https://github.com/user-attachments/assets/854452d7-1205-4ede-84ec-ff2f73383685"></video> |  <video width="300" src="https://github.com/user-attachments/assets/d6139ff5-e614-4f0e-8e50-0a41ee050cd5" />  |




