### PR TITLE
Introduce getDiffProps for <View> (#45552)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -133,4 +133,25 @@ SharedDebugStringConvertibleList HostPlatformViewProps::getDebugProps() const {
 }
 #endif
 
+#ifdef ANDROID
+
+folly::dynamic HostPlatformViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  static const auto defaultProps = HostPlatformViewProps();
+
+  const HostPlatformViewProps* oldProps = prevProps == nullptr
+      ? &defaultProps
+      : static_cast<const HostPlatformViewProps*>(prevProps);
+
+  if (focusable != oldProps->focusable) {
+    result["focusable"] = focusable;
+  }
+
+  return result;
+}
+
+#endif
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
@@ -55,6 +55,12 @@ class HostPlatformViewProps : public BaseViewProps {
 #if RN_DEBUG_STRING_CONVERTIBLE
   SharedDebugStringConvertibleList getDebugProps() const override;
 #endif
+
+#ifdef ANDROID
+
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+
+#endif
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
## TL;DR

This cherry-picks this PR on top of our RN 0.78 branch to fix some rendering issues happening on new arch:

- https://github.com/facebook/react-native/pull/45552

## Details 

When using FlashList with new arch on our RN 0.78 build we were seeing weird layout bugs:

- https://github.com/Shopify/flash-list/issues/1576#issue-2942491997

after testing we found that on RN 0.79 these issues don't happen. I ran a bisect and found that this commit fixes the issue.

### Weird details

Now, its odd that this commit is fixing the issue, as the function `getDiffProps` is nowhere called during runtime! (There is one call site in `android/FabricMountingManager.cpp` but thats behind a feature flag that is false).

My best assumption is that in release mode (the only place where the bug happens) some optimization flags are applied which cause some corruption (messing with the vtable as this is a virtual function?). In debug those flags aren't applied and so the bug doesn't happen.
